### PR TITLE
Fix audio loading loop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -156,6 +156,8 @@ class AuthWrapper extends StatefulWidget {
 }
 
 class _AuthWrapperState extends State<AuthWrapper> {
+  bool _hasInitializedProviders = false;
+  
   @override
   void initState() {
     super.initState();
@@ -225,14 +227,18 @@ class _AuthWrapperState extends State<AuthWrapper> {
         }
 
         if (authProvider.isAuthenticated) {
-          final playerProvider = context.read<PlayerProvider>();
-          final cacheProvider = context.read<CacheProvider>();
-          playerProvider.setApi(authProvider.api!);
-          cacheProvider.initialize(authProvider.api!);
-          
-          // Initialize MPRIS service for Linux
-          if (Platform.isLinux) {
-            MprisService.instance.initialize(playerProvider);
+          // Only initialize providers once to prevent multiple setApi calls
+          if (!_hasInitializedProviders) {
+            _hasInitializedProviders = true;
+            final playerProvider = context.read<PlayerProvider>();
+            final cacheProvider = context.read<CacheProvider>();
+            playerProvider.setApi(authProvider.api!);
+            cacheProvider.initialize(authProvider.api!);
+            
+            // Initialize MPRIS service for Linux
+            if (Platform.isLinux) {
+              MprisService.instance.initialize(playerProvider);
+            }
           }
           
           return const HomeScreen();

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -119,6 +119,12 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   void setApi(NavidromeApi api) {
+    // Check if the API is already set to the same instance
+    if (_api == api) {
+      print('[PlayerProvider] API already set to same instance, skipping');
+      return;
+    }
+    
     _api = api;
     _cacheService = CacheService(api: api);
     // Update the audio handler with the proper API if on Android
@@ -130,6 +136,12 @@ class PlayerProvider extends ChangeNotifier {
   }
   
   Future<void> _restoreAudioIfNeeded() async {
+    // Check if already restoring to prevent concurrent operations
+    if (_isRestoring) {
+      print('[PlayerProvider] Already restoring, skipping concurrent restore');
+      return;
+    }
+    
     if (_currentSong != null && _api != null && !_hasRestoredPosition) {
       _isRestoring = true;
       print('[PlayerProvider] API set, restoring audio for ${_currentSong!.title}');


### PR DESCRIPTION
## Summary
- Fixes the audio loading loop that was causing repeated "Loading interrupted" errors on app startup
- Prevents multiple concurrent calls to `_restoreAudioIfNeeded()`
- Ensures `setApi()` is only called once during initialization

## Changes
- Added check in `PlayerProvider.setApi()` to prevent redundant API setting when the same instance is passed
- Added concurrent operation prevention in `_restoreAudioIfNeeded()` using the existing `_isRestoring` flag
- Modified `AuthWrapper` to track provider initialization and only call `setApi()` once
- Added `_hasInitializedProviders` flag to prevent multiple initialization during widget rebuilds

## Test plan
- [x] App starts without showing login screen flash
- [x] No "Loading interrupted" errors in console
- [x] Audio playback still works correctly
- [x] Previously playing song is restored on app restart
- [x] Dynamic theming continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)